### PR TITLE
Docs: minor fixes & update Sphinx to 8.1.3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'voc4cat-guidelines'
-copyright = '2024, Nikolaos Moustakas, David Linke'
-author = 'Nikolaos Moustakas, David Linke'
-release = '2.0'
+project = 'Voc4Cat'
+copyright = '2024, Voc4Cat contributors'
+author = 'David Linke, Nikolaos Moustakas, and Voc4Cat contributors'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -33,6 +32,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
 html_theme = 'furo'
 html_static_path = ['_static']
 html_favicon = '_static/favicon_32.png'
+html_last_updated_fmt = '%Y-%m-%d'
 
 # -- Options for todo extension -----------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#module-sphinx.ext.todo

--- a/docs/docs_maintenance/creating-docs-locally.md
+++ b/docs/docs_maintenance/creating-docs-locally.md
@@ -4,7 +4,7 @@ You need a recent Python version on your computer and a local clone of the repos
 
 The following commands should be run from the root directory of the clone.
 
-First, install the required packages into a virtual environment. The documentation is build with Sphinx and MyST for markdown support.
+First, install the required packages into a virtual environment. The documentation is built with Sphinx and MyST for markdown support.
 
 ```bat
 py -m venv .venv

--- a/docs/docs_usage/guidelines.md
+++ b/docs/docs_usage/guidelines.md
@@ -16,8 +16,7 @@ The guidelines have been through excessive discussions and were evolved
 over the course of *Task Area 1 (TA1): Ontology Development and Metadata
 Standards* of NFDI4Cat.
 
-Please note that all language dependent
-parts refer to only the default language (**British English**).
+Please note that all language dependent parts refer to only the default language (British English).
 
 ## General recommendations
 
@@ -96,7 +95,7 @@ considerations should be followed when adding definitions:
 6. A definition of a concept should not start with mentioning the
     concept that it defines.
 
-7. If the source of a definition is not the contributor, the use of a
+7. If the source of a definition is not the contributor, a
     trusted and stable source should be used. Credit must be given to
     the original creator. When copyright or license is restrictive, it
     must be respected. To identify the source, a URL, or a descriptive

--- a/docs/docs_usage/how-to-contribute.md
+++ b/docs/docs_usage/how-to-contribute.md
@@ -1,6 +1,8 @@
 # How to contribute to Voc4Cat?
 
 ```{todo}
-Move and merge documentation on contribution process from [readme](https://github.com/nfdi4cat/voc4cat/blob/main/README.md#contributing-to-vocabularies)
-and {ref}`guidelines-v2.0 <docs_usage/published-guidelines-v2:5. contribution step-by-step guide>` here.
+Move and merge documentation on contributing to the vocabulary from [readme](https://github.com/nfdi4cat/voc4cat/blob/main/README.md#contributing-to-vocabularies)
+and {ref}`guidelines-v2.0 <docs_usage/published-guidelines-v2:5. contribution step-by-step guide>` to this page.
+
+We should maybe also add a section about how to contribute to this dcoumentation.
 ```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -56,7 +56,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.0.2
+sphinx==8.1.3
     # via
     #   -r requirements.in
     #   furo


### PR DESCRIPTION
This fixes some typos in the documentation, adjusts the copyright text in the footer and adds the doc-build date to the footer.