### PR TITLE
Add a CODEOWNERS file to select suitable PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# For more on what a codeowners file does and its syntax see
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, the team @nfdi4cat/voc4cat-curators
+# will be requested for review when someone opens a pull request.
+*       @nfdi4cat/voc4cat-curators


### PR DESCRIPTION
Up to now all members of the nfdi4cat organization are suggested as possible reviewers for pull requests. This does not make much sense. Instead only those with voc4cat knowledge should be suggested.

To influence who is suggested as reviewer a `.github/CODEOWNERS` file cab be added to the repository which allows to assign users or teams to all contents in a repository (or even to only parts of it). The initial CODEOWNERS file added in this PR assigns the code-ownership to the new team [nfdi4cat/voc4cat-curators](https://github.com/orgs/nfdi4cat/teams/voc4cat-curators).
