### PR TITLE
Update underlying template & voc4cat-tool to v0.8.7

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,7 +59,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.5
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.7
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x  (adds sorted collections,

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -55,7 +55,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.5
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.7
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.5
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.7
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,7 +1,7 @@
 @misc{david_linke_2023_8313340,
   author       = {David Linke, voc4cat contributors},
   title        = {nfdi4cat/voc4cat - A SKOS vocabulary for the catalysis disciplines.},
-  year         = {2023},
+  year         = {2023--2025},
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.8313340},
   url          = {https://doi.org/10.5281/zenodo.8313340}

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ For details see the Zenodo record.
 
 All vocabularies in this repository are CC0-1.0 licensed, see [LICENSE](LICENSE) for details.
 
-### Voc4cat template
+### Voc4Cat template
 
-The template itself is CC0-1.0 licensed, see [LICENSE](https://github.com/nfdi4cat/voc4cat-template/blob/main/LICENSE).
-Although there is no obligation, we nevertheless appreciate if our work is acknowledged in any derivative work.
+The template itself is CC0-1.0 licensed, see [LICENSE](https://github.com/nfdi4cat/voc4cat-template/blob/main/LICENSE). 
+Although there is no obligation, we will nevertheless highly appreciate if you acknowledge our work in any derivative work.
 
 ## Acknowledgement
 

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -1,0 +1,163 @@
+# Voc4Cat Template Help
+
+> The presence of this file indicates that this vocabuary is based on [voc4cat-template](https://github.com/nfdi4cat/voc4cat-template).<BR>
+> To **avoid merge conflicts on updates**, this file should mainly change via merging an updated version from the template repository. Therefore, please consider submitting your requests for changes/improvements as [issue in the voc4cat-template](https://github.com/nfdi4cat/voc4cat-template/issues/new?template=Blank+issue) repository.
+
+## How to start?
+
+### Trying out the workflow
+
+To experience the workflow, we suggest that you try contributing to [voc4cat](https://github.com/nfdi4cat/voc4cat) which is a "deployment" of this repository.
+If you are interested in understanding the technical details or in developing your own vocabulary,
+follow the instructions [below](#how-to-use-this-template-for-your-own-vocabularies).
+
+All vocabularies based on this template have the same standard contribution process of
+
+- get and update the vocabulary file (xlsx),
+- submit a pull request with the updated file,
+- collaborate on the pull request with editors or other github users,
+
+After approval your pull request is ready to be merged by the editors. The merge will include your contribution into the SKOS-vocabulary file in the `vocabularies`-folder. Upon merge the corresponding documentation and a joined turtle file will be automatically built and published to gh-pages.
+
+The Excel/xlsx files submitted as pull request are automatically checked and (if all is good) converted to turtle.
+By using a vocabulary-specific configuration more thorough validation can be activated,
+e.g. if terms get removed in a PR or if correct IRIs are used.
+To validate IRIs the configuration supports ID-ranges (similar to [OBO idrange](https://oboacademy.github.io/obook/howto/idrange/) but we use the [toml](https://toml.io/)-format).
+The idea is that every author gets their own range of IDs to consume.
+This allows independent work and avoids using the same ID repeatedly.
+
+The voc4cat-template implements automatic storage of different versions of the vocabularies in gh-pages:
+
+- `dev` - Directory with artifacts built from the most recent commit to the main branch.
+- `latest` - Directory with all files built for the latest release.
+- `vYYYY-MM-DD` (for example `v2023-08-16`) - Directory with all files built for the release with this tag.
+
+For all versions, multiple files are stored (see https://github.com/nfdi4cat/voc4cat-template/issues/11#issuecomment-1680592185 for details). The correct version string is automatically inserted to all build artifacts. For `dev`, the first eight characters of the commit hash are used as version (for example `v_fadfa5f9`).
+
+- Taking into account the above scheme, the url for the artifacts for the `dev` version in gh-pages is `https://{gh-org-name}.github.io/{repository-name}/dev/{vocabulary-name}/`
+- For example, in repository `nfdi4cat/voc4cat-template` the vocabulary `vocab_example` is documented at [https://nfdi4cat.github.io/voc4cat-template/dev/vocab_example/](https://nfdi4cat.github.io/voc4cat-template/dev/vocab_example/)
+
+In addition to the specific versions, an index page is generated that links to all vocabularies and the tagged releases.
+It is placed at the root of gh-pages (`https://{gh-org-name}.github.io/{repository-name}/`).
+
+### Creating vocabularies for catalysis or catalytic reaction engineering
+
+Please strongly consider contributing to [voc4cat](https://github.com/nfdi4cat/voc4cat) instead of creating your own.
+
+## Contributing to vocabularies
+
+To discuss about the SKOS vocabularies maintained with this template, create an issue in the vocabulary repository itself (but not in this template-repository).
+
+To contribute new concepts or collections or change existing ones, you may either submit your contributions as Excel/xlsx-file or (as an expert) as new/changed turtle file.
+
+Here are the steps for submitting updates in Excel.
+
+- Get the Excel/xlsx-vocabulary file
+  - The most recent version of the vocabulary is always available via github-pages.
+    - The general url is `https://{gh-org-name}.github.io/{repository-name}/dev/{vocabulary-name}.xlsx`
+    - For example in nfdi4cat/voc4cat-template the most recent vocabulary `vocab_example` can be downloaded from [https://nfdi4cat.github.io/voc4cat-template/dev/vocab_example.xlsx](https://nfdi4cat.github.io/voc4cat-template/dev/vocab_example.xlsx)
+  - For setting up a new vocabulary, use the xlsx-file from the templates-folder.
+- Make changes to the Excel file
+- Add the xlsx file to your clone of the repository into the folder `inbox-excel-vocabs`
+  - The name of the file must match the vocabulary that you want to update (e.g. myvoc.xlsx to update a vocabulary named "myvoc").
+  - New vocabularies will be named like the xlsx-file (minus the `.xlsx`-extension).
+- Create a pull request with the updated Excel-file on GitHub.
+  - Please describe your changes and the motivation for the changes in the pull request note or link to an issue with this information. This will help reviewers to understand the proposed change and decide about it.
+- Your pull request will be processed automatically by a CI/CD pipeline that typically runs less than a minute.
+- Review the artifacts/logs generated by the CI pipeline.
+  - The [workflow artifact](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts) will contain an updated xlsx file that is recreated from the updated turtle-file.
+- If all is good your contribution will be either
+  - directly merged by the maintainers
+  - or a discussion will be started about what else is needed
+  - or why the proposed change may not fit.
+- If you need to fix something update the pull request branch. This will trigger the pipeline to run again.
+
+Finally, when the proposed pull request is accepted, your changes will be integrated in the vocabularies in the folder `vocabularies`. The vocabularies are stored in split form using one folder per vocabulary. Each concept, collection and concept scheme is stored in a separate file using the ID-part of the IRI as file name.
+
+See [inbox-excel-vocabs/README.md](inbox-excel-vocabs/README.md) for a minimal example how to test the submission process.
+
+## How to suggest improvements to the tooling & template?
+
+To discuss about the workflow for maintaining SKOS vocabularies based on this template, create an [voc4cat-template issue](https://github.com/nfdi4cat/voc4cat-template/issues).
+
+To discuss about the tool that converts Excel to SKOS in gh-actions of this template, create an [voc4cat-tool issue](https://github.com/nfdi4cat/voc4cat-tool/issues).
+
+## How to use this template for your own vocabularies?
+
+The template can be used to create your own independent repository for SKOS vocabularies maintenance.
+
+### Setting up your own github repository
+
+First create a new repository on github without any contents, named e.g. "my-new-vocabulary". Then set up your own independent vocabulary repository on the command line:
+
+```gitattributes
+git init my-new-vocabulary
+cd my-new-vocabulary
+git pull https://github.com/nfdi4cat/voc4cat-template
+git remote add origin https://github.com/my-gh-name/my-new-vocabulary.git
+git push -u origin main
+```
+
+This adds all commits made in the template´s main branch to your new repository. In addition to this basic setup you may want to
+
+- Adjust the README.md file for your vocabulary.
+- Adjust the configuration of your vocabularies in `idranges.toml`
+- Adjust settings of your new GitHub repository. Typically you will want to
+  - Forbid pushing to main via [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) (Settings > Branches, edit rules for "main")
+  - Set up rules for required approvals (Settings > Branches, edit rules for "main")
+  - Configure GitHub pages to use as source "deploy from a branch" and select the branch `gh-pages` (Settings > Pages > Build and deployment)
+- Optionally
+  - Add a different license for your vocabulary.
+  - Adjust the styling of the Excel template for your vocabulary.
+
+After these steps your repository should work just like [voc4cat](https://github.com/nfdi4cat/voc4cat).
+
+### Keeping your vocabulary repository in sync with the voc4cat-template
+
+To review the changes made in the template after you last pulled it use:
+
+```gitattributes
+git fetch https://github.com/nfdi4cat/voc4cat-template
+git diff ...FETCH_HEAD
+```
+
+If you want to take over the changes, pull them into your repository
+
+```gitattributes
+git pull https://github.com/nfdi4cat/voc4cat-template
+```
+
+and push the change to the remote repository.
+
+```gitattributes
+git push
+```
+
+It is suggested to merge the changes from the template repository before every new release of your vocabulary. This ensures that the centrally maintained features and best practices trickle into your project.
+
+## Working with voc4cat-tools on your own computer
+
+This repository template contains a `justfile` which pre-defines series of commands as tasks. Theses tasks are run with the [just command runner](https://github.com/casey/just).
+
+In the justfile, [uv](https://docs.astral.sh/[uv](https://docs.astral.sh/uv/)/) is used to install and update the Python package [voc4cat](https://pypi.org/project/voc4cat/).
+
+The justfile helps to tun (almost) the same commands as are used in the GitHub workflows locally on your computer.
+This makes local testing of a modified vocabulary xlsx-file easier.
+Read the header of the justfile for more info on setting up your environment.
+
+Once you have `just` installed type the command `just` at the root of the git-project to list the available commands. For version 0.8.7 of the template, it gives:
+
+```bash
+$ just
+Available recipes:
+    all     # Run all steps as in gh-actions: check xlsx, convert to SKOS, build docs, re-build xlsx
+    check   # Check the voc4cat.xlsx file in inbox/ for errors
+    clean   # Remove all generated files/directories
+    convert # Convert the voc4cat.xlsx file in inbox/ to turtle
+    docs    # Run voc4cat (build HTML documentation from ttl files)
+    setup   # Run initial setup (run this first)
+    update  # Updates voc4cat-tool installation
+    xlsx    # Rebuild the xlsx file from the joined ttl file.
+```
+
+If you have some Python knowledge, you can of course also install and use the [voc4cat](https://pypi.org/project/voc4cat/) Python package just like any other Python package, starting with `pip install voc4cat` and continuing from there.

--- a/justfile
+++ b/justfile
@@ -57,6 +57,8 @@ convert: _fake_actions_env
   fi
 
   #=== post-convert checks ===
+  # Delete xlsx in outbox that may be present from former runs
+  @rm -f outbox/voc4cat.xlsx
   # check all ttl file(s) in outbox
   @voc4cat check --config _main_branch/idranges.toml --logfile outbox/voc4cat.log outbox/
   # check if vocabulary changes are allowed
@@ -66,8 +68,13 @@ convert: _fake_actions_env
 docs:
   @voc4cat docs --logfile outbox/voc4cat.log --force outbox/
 
-# Run combination of steps as in gh-actions: check xlsx, convert to SKOS, build docs
-all: check convert docs
+# Rebuild the xlsx file from the joined ttl file.
+xlsx:
+  @rm -f outbox/voc4cat.xlsx
+  @voc4cat convert --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/
+
+# Run all steps as in gh-actions: check xlsx, convert to SKOS, build docs, re-build xlsx
+all: check convert docs xlsx
 
 # Create local environment suitable to run the same commands as in gh-actions
 _fake_actions_env:
@@ -75,7 +82,7 @@ _fake_actions_env:
   @mkdir -p _main_branch/vocabularies
   @cp idranges.toml _main_branch/idranges.toml
 
-# # Clean all generated files
+# Remove all generated files/directories
 clean:
   rm -rf outbox
   rm -rf outbox_new_voc


### PR DESCRIPTION
Main changes:
- Update to [voc4cat-template v0.8.7](https://github.com/nfdi4cat/voc4cat-template/releases/tag/v0.8.7) of which uses [voc4cat-tool v0.8.7](https://github.com/nfdi4cat/voc4cat-tool/releases/tag/v0.8.7) (from 0.8.5) in the actions. This fixes and improves adding mappings via the "Additional Concept Features" sheet.
  - Related: #118.
- Improve the commands in the recently added `justfile` and add another command `xlsx` to re-build xlsx from turtle.
- Add the new template-related `README_TEMPLATE.md`.