### PR TITLE
Update underlying template & voc4cat-tool to v0.8.8

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,7 +59,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.7
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.8
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x  (adds sorted collections,
@@ -104,7 +104,7 @@ jobs:
       - name: Split vocabulary and merge into vocabulary dir (in PR branch)
         run: |
           voc4cat transform --split --inplace --logfile outbox/voc4cat.log --outdir outbox_new_voc outbox/
-          merge_vocab --logfile outbox/voc4cat.log  outbox_new_voc/ vocabularies/
+          voc4cat-merge --logfile outbox/voc4cat.log  outbox_new_voc/ vocabularies/
           # copy xlsx to outbox so that the xlsx file is part of the artifact
           find inbox-excel-vocabs -name '*.xlsx' -exec cp {} -t outbox/ \;
           git status

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -55,7 +55,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.7
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.8
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.7
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.8
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/justfile
+++ b/justfile
@@ -30,15 +30,18 @@ src := "src"
 set ignore-comments	:= true
 
 # Run initial setup (run this first)
+[group('environment')]
 setup:
   # install current voc4cat-tool version
   uv tool install voc4cat --with git+https://github.com/dalito/pyLODE.git@nfdi4cat-2.x
 
-# Updates voc4cat-tool installation
-update:
-  uv tool install voc4cat
+# Upgrades voc4cat-tool installation
+[group('environment')]
+upgrade:
+  uv tool install --upgrade voc4cat --with git+https://github.com/dalito/pyLODE.git@nfdi4cat-2.x
 
 # Check the voc4cat.xlsx file in inbox/ for errors
+[group('individual steps')]
 check: _fake_actions_env
   @voc4cat --version
   # check inbox file names
@@ -47,6 +50,7 @@ check: _fake_actions_env
   @voc4cat check --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --outdir outbox inbox-excel-vocabs/
 
 # Convert the voc4cat.xlsx file in inbox/ to turtle
+[group('individual steps')]
 convert: _fake_actions_env
   # make a backup of the original file just in case
   @cp inbox-excel-vocabs/voc4cat.xlsx inbox-excel-vocabs/voc4cat.xlsx.backup
@@ -65,13 +69,20 @@ convert: _fake_actions_env
   @voc4cat check --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --ci-post _main_branch/vocabularies outbox/
 
 # Run voc4cat (build HTML documentation from ttl files)
+[group('individual steps')]
 docs:
   @voc4cat docs --logfile outbox/voc4cat.log --force outbox/
 
 # Rebuild the xlsx file from the joined ttl file.
+[group('individual steps')]
 xlsx:
   @rm -f outbox/voc4cat.xlsx
   @voc4cat convert --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/
+
+# Join individual ttl files in vocabularies/ to one turtle file in outbox/
+[group('individual steps')]
+join:
+  @voc4cat transform --logfile outbox/voc4cat.log -O outbox --join vocabularies/
 
 # Run all steps as in gh-actions: check xlsx, convert to SKOS, build docs, re-build xlsx
 all: check convert docs xlsx
@@ -83,6 +94,7 @@ _fake_actions_env:
   @cp idranges.toml _main_branch/idranges.toml
 
 # Remove all generated files/directories
+[group('environment')]
 clean:
   rm -rf outbox
   rm -rf outbox_new_voc


### PR DESCRIPTION
[Release v0.8.8](https://github.com/nfdi4cat/voc4cat-tool/releases/tag/v0.8.8) of voc4cat-tool fixes a bug that broke our workflow runs (affected only today).

This update also improves and extends the commands in the `justfile`.

