### PR TITLE
Move code ownership for templates to dalito

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,8 @@
 # will be requested for review when someone opens a pull request.
 *       @nfdi4cat/voc4cat-curators
 
-# Curators should not take care of technical details of gh-actions or
-# manage code ownership. This is currently taken care of by dalito.
+# Curators should not take care of technical details of gh-actions,
+# the template or manage code ownership.
+# This is currently taken care of by dalito.
+/templates/ @dalito
 /.github/ @dalito


### PR DESCRIPTION
Follow-up of #131:

Changing the xslx-template has to be done in careful coordination with voc4cat-tool and gh-action changes. This requires more expertise on how all tools in voc4cat play together than the members of the vocabulary-curator team should have. So this moves the ownership from the curator team to the tool developer.