### PR TITLE
Update underlying template & voc4cat-tool to v0.9.0

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,7 +59,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.8
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.9.0
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x  (adds sorted collections,

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,4 +1,4 @@
-# This action runs on merges of turtle files to main.
+# This action runs on merge to main.
 #
 # Workflow steps:
 # - checkout gh-pages for updating
@@ -8,13 +8,17 @@
 # - build sphinx docs/site
 # - publish docs, vocabulary-turtle files and excel-file to gh-pages
 
-name: Build
+name: Merge & re-build
 on:
   push:
     branches:
       - main
     paths:
+      - 'idranges.toml'
+      - '.zenodo.json'
+      - '.github/workflows/**.yml'
       - 'docs/**'
+      - 'templates/**.xlsx'
       - 'vocabularies/**.ttl'
   workflow_dispatch:
 
@@ -55,7 +59,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.8
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.9.0
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x
@@ -84,8 +88,9 @@ jobs:
           mv publish/dev/index.html publish/
 
       - name: Run voc4cat (build current Excel file)
+        # Passing the config is important to make use of the prefixes therein.
         run: |
-          voc4cat convert --logfile publish/dev/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/dev/
+          voc4cat convert --config _main_branch/idranges.toml --logfile publish/dev/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/dev/
 
       - name: Run voc4cat (build vocabulary in xml/rdf from Excel file)
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # install tagged version
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.8.8
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v0.9.0
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x
@@ -80,8 +80,9 @@ jobs:
           mv publish/latest/index.html publish/
 
       - name: Run voc4cat (build current Excel file)
+        # Passing the config is important to make use of the prefixes therein.
         run: |
-          voc4cat convert --logfile publish/latest/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/latest/
+          voc4cat convert --config _main_branch/idranges.toml --logfile publish/latest/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/latest/
 
       - name: Run voc4cat (build vocabulary in xml/rdf from Excel file)
         run: |

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ docs:
 [group('individual steps')]
 xlsx:
   @rm -f outbox/voc4cat.xlsx
-  @voc4cat convert --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/
+  @voc4cat convert --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/
 
 # Join individual ttl files in vocabularies/ to one turtle file in outbox/
 [group('individual steps')]

--- a/templates/README.md
+++ b/templates/README.md
@@ -4,6 +4,12 @@ The templates here match structure-wise with the templates in [Voc4Cat-tool](htt
 
 ### Version 0.4.3
 
+#### Revision 2025-02a
+
+- Update help to reflect the prefix sheet is read-only.
+- Update introduction to reflect progress of tooling.
+- Adjust column widths for better compatibility with new IRI notation with qualifier.
+
 #### Revision 2023-08b
 
 - Cells version and modified date in concept scheme sheet are now optional. Updated notes accordingly.


### PR DESCRIPTION
- Adds nicer and more consistent styling to the auto-created xlsx vocabulary file.
- Switches to CURIE-notation by default.
- For columns where the Id is not directly besides the preferred label column we add now the preferred label as a qualifier `voc4cat:0000141 (liquid chromatography)` also helps a lot with quickly seeing what an ID stands for.
- Note that the sheet "Prefixes" is now read-only. If you need certain prefixes we have to add them to ` idranges.toml`. This way they are shared among allo users of voc4cat. Please make a pull request if you need a prefix not yet present.

Closes #133