### PR TITLE
Re-build updated xlsx in PRs

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -109,6 +109,12 @@ jobs:
           find inbox-excel-vocabs -name '*.xlsx' -exec cp {} -t outbox/ \;
           git status
 
+      - name: Run voc4cat (re-build an updated Excel file)
+        # Passing the config is important to make use of the prefixes therein.
+        run: |
+          mkdir -p outbox/updated-xlsx
+          voc4cat convert --config idranges.toml --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/updated-xlsx
+
       - name: Store artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This will be helpful in bigger PRs where the user (and reviewers) need access to an xlsx-file with all changes from the PR (for example in #151). The updated xlsx file is included in the job-artifact that can be downloaded on the job´s summary page.
