### PR TITLE
Supply idranges.toml config for conversion to xml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,8 +85,9 @@ jobs:
           voc4cat convert --config idranges.toml --logfile publish/latest/voc4cat.log --template templates/voc4cat_template_043.xlsx publish/latest/
 
       - name: Run voc4cat (build vocabulary in xml/rdf from Excel file)
+        # Passing the config is important to make use of the prefixes therein.
         run: |
-          voc4cat convert --logfile publish/latest/voc4cat.log --outputformat xml publish/latest/voc4cat.xlsx
+          voc4cat convert --config idranges.toml --logfile publish/latest/voc4cat.log --outputformat xml publish/latest/voc4cat.xlsx
 
       - name: Copy release to release-name directory
         run: |

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Producing Voc4Cat-annotated data contributes to realising the vision of machine-
 ```
 
 +++
-<small>Latest release **v2024-12-17**</small>
+<small>Latest release **v2025-05-21**</small>
 :::
 ::::
 

--- a/idranges.toml
+++ b/idranges.toml
@@ -21,6 +21,7 @@ allow_delete = false
 
 [vocabs.voc4cat.prefix_map]
 voc4cat = "https://w3id.org/nfdi4cat/voc4cat_"
+
 # Section of IDranges for coordinating the allocation of numeric ID ranges to
 # contributors for each vocabulary. Each idrange contains the same keys:
 #


### PR DESCRIPTION
Adds `--config idrange.toml` to the command for the conversion to xml. Without the config the prefix "voc4cat" is unknown. This  caused the failure of the publish job for Release v2025-05-21. Since we haven't created releases for quite some time this issue was not noticed before.

This PR fixes the underlying issue of #171. 
