### PR TITLE
Update Sphinx and dependencies for docs

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,4 +1,4 @@
-# Compile to requirements.txt with `pip-compile requirements.in`
+# Compile to requirements.txt with `pip-compile --upgrade requirements.in`
 Sphinx
 myst-parser
 furo

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,16 +4,21 @@
 #
 #    pip-compile requirements.in
 #
+--index-url https://pypi.catalysis.de/likat/stable
+--trusted-host pypi.catalysis.de
+
 alabaster==1.0.0
     # via sphinx
-babel==2.16.0
+babel==2.17.0
     # via sphinx
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.4
     # via furo
-certifi==2024.8.30
+certifi==2025.6.15
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via requests
+colorama==0.4.6
+    # via sphinx
 docutils==0.21.2
     # via
     #   myst-parser
@@ -32,29 +37,31 @@ markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
     #   myst-parser
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via jinja2
 mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==4.0.0
+myst-parser==4.0.1
     # via -r requirements.in
-packaging==24.1
+packaging==25.0
     # via sphinx
-pygments==2.18.0
+pygments==2.19.2
     # via
     #   furo
     #   sphinx
 pyyaml==6.0.2
     # via myst-parser
-requests==2.32.3
+requests==2.32.4
     # via sphinx
-snowballstemmer==2.2.0
+roman-numerals-py==3.1.0
     # via sphinx
-soupsieve==2.6
+snowballstemmer==3.0.1
+    # via sphinx
+soupsieve==2.7
     # via beautifulsoup4
-sphinx==8.1.3
+sphinx==8.2.3
     # via
     #   -r requirements.in
     #   furo
@@ -83,5 +90,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-urllib3==2.2.3
+typing-extensions==4.14.0
+    # via beautifulsoup4
+urllib3==2.5.0
     # via requests


### PR DESCRIPTION
This PR addresses reported security vulnerabilities for requests<2.32.4 and urllib3<2.5.0 by updating them. 
It also updates Sphinx to the latest version 8.2.3 (from 8.1.3).