### PR TITLE
Add idrange for b-elisa

### DIFF
--- a/idranges.toml
+++ b/idranges.toml
@@ -122,4 +122,10 @@ gh_name = "mvoelken-hub"
 orcid = "0009-0006-1375-2895"
 ror_id = "https://ror.org/01k97gp34"
 
+[[vocabs.voc4cat.id_range]]
+first_id = 8061
+last_id = 8080
+gh_name = "b-elisa"
+ror_id = "https://ror.org/03v4gjf40"
+
 # Continue with as many [[vocabs.voc4cat.id_range]] sections as needed.


### PR DESCRIPTION
Hi @b-elisa,

Thanks for your interest in contributing to voc4cat. 😸
This reserves the IDs from 8061 to 8080 for you.

While it should work to contribute without a real name or ORCID (no one tested before you), we cannot add you to the contributors of the Zenodo publication then. But you can later on submit your name or ORCID if you change your mind.

Closes #187