### PR TITLE
Update dependencies incl. safe urllib version

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,4 +1,5 @@
 # Compile to requirements.txt with `pip-compile --upgrade requirements.in`
+# With uv: `uv pip compile --upgrade requirements.in -o requirements.txt`
 Sphinx
 myst-parser
 furo

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,9 +6,9 @@ alabaster==1.0.0
     # via sphinx
 babel==2.17.0
     # via sphinx
-beautifulsoup4==4.14.2
+beautifulsoup4==4.14.3
     # via furo
-certifi==2025.10.5
+certifi==2025.11.12
     # via requests
 charset-normalizer==3.4.4
     # via requests
@@ -18,7 +18,7 @@ docutils==0.21.2
     # via
     #   myst-parser
     #   sphinx
-furo==2025.9.25
+furo==2025.12.19
     # via -r requirements.in
 idna==3.11
     # via requests
@@ -53,11 +53,13 @@ pyyaml==6.0.3
     #   sphinxcontrib-mermaid
 requests==2.32.5
     # via sphinx
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
+    # via roman-numerals-py
+roman-numerals-py==4.1.0
     # via sphinx
 snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.8
+soupsieve==2.8.1
     # via beautifulsoup4
 sphinx==8.2.3
     # via
@@ -85,7 +87,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-mermaid==1.0.0
+sphinxcontrib-mermaid==1.2.3
     # via -r requirements.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
@@ -93,5 +95,5 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 typing-extensions==4.15.0
     # via beautifulsoup4
-urllib3==2.5.0
+urllib3==2.6.2
     # via requests


### PR DESCRIPTION
This fixes a potential security problem with urllib < 2.6.0 reported by depandabot.