### PR TITLE
Fix order of steps for rebuilding xlsx in CI for PRs

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -117,8 +117,8 @@ jobs:
         # Passing the config is important to make use of the prefixes therein.
         run: |
           mkdir -p outbox/updated-xlsx-ttl
-          voc4cat convert --config idranges.toml --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/updated-xlsx-ttl
           voc4cat transform --config idranges.toml --logfile outbox/voc4cat.log -O outbox/updated-xlsx-ttl --join vocabularies/
+          voc4cat convert --config idranges.toml --logfile outbox/voc4cat.log --template templates/voc4cat_template_043.xlsx outbox/updated-xlsx-ttl
 
       - name: Store artifacts
         if: ${{ always() }}


### PR DESCRIPTION
Fix that no updated xlsx is present in CI-PR build artifact. The build order was wrong.

This PR fixes the order: FIrst, we have to join for a new voc4cat.ttl, than we can convert to xlsx.