### PR TITLE
Fix prefLabel to lowercase; remove altLabel for 8101

### DIFF
--- a/vocabularies/voc4cat/IDs0008xxx/0008101.ttl
+++ b/vocabularies/voc4cat/IDs0008xxx/0008101.ttl
@@ -8,7 +8,7 @@ voc4cat:0008101
     a skos:Concept ;
     dcterms:created "2025-12-28"^^xsd:date ;
     dcterms:identifier "0008101"^^xsd:token ;
-    dcterms:modified "2025-12-31"^^xsd:date ;
+    dcterms:modified "2026-01-01"^^xsd:date ;
     dcterms:provenance <https://github.com/nfdi4cat/voc4cat/blame/main/vocabularies/voc4cat/0008101.ttl> ;
     rdfs:seeAlso <https://github.com/nfdi4cat/voc4cat/blame/main/vocabularies/voc4cat/0008101.ttl> ;
     skos:broader voc4cat:0000185 ;

--- a/vocabularies/voc4cat/IDs0008xxx/0008102.ttl
+++ b/vocabularies/voc4cat/IDs0008xxx/0008102.ttl
@@ -8,7 +8,7 @@ voc4cat:0008102
     a skos:Concept ;
     dcterms:created "2025-12-28"^^xsd:date ;
     dcterms:identifier "0008102"^^xsd:token ;
-    dcterms:modified "2025-12-31"^^xsd:date ;
+    dcterms:modified "2026-01-01"^^xsd:date ;
     dcterms:provenance <https://github.com/nfdi4cat/voc4cat/blame/main/vocabularies/voc4cat/0008102.ttl> ;
     rdfs:seeAlso <https://github.com/nfdi4cat/voc4cat/blame/main/vocabularies/voc4cat/0008102.ttl> ;
     skos:broader voc4cat:0000185 ;


### PR DESCRIPTION
This PR fixes the concepts to lowercase to match the guidelines and removes an alt:Label which is not an altLabel but a related concept.