### PR TITLE
Fix generated sitemap url-scheme

### DIFF
--- a/docs/_static/sitemap_vocab.xml
+++ b/docs/_static/sitemap_vocab.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html </loc>
+    <loc>https://nfdi4cat.github.io/voc4cat/latest/voc4cat/index.html</loc>
   </url>
 </urlset>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,7 @@ myst_heading_anchors = 3
 
 # -- Options for sitemap extension -------------------------------------------
 # https://sphinx-sitemap.readthedocs.io/en/latest/configuration.html
+sitemap_url_scheme = "{link}"  # use html_baseurl as is, without language code prefix
 sitemap_show_lastmod = True
 sitemap_indent = 2
 


### PR DESCRIPTION
The sitemap generation included a language tag in the URL which we don't use. This PR fixes the URL generation.
