### PR TITLE
Update to voc4cat template v26.1 / voc4cat-tool v1.0.4

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -73,7 +73,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Select to install a stable tagged version or main branch (in development)
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.0.3
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.0.4
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x  (adds sorted collections,
@@ -120,7 +120,7 @@ jobs:
           find inbox-excel-vocabs -name '*.xlsx' -exec cp {} -t outbox/ \;
           git status
           # Add/update dct:created and dct:modified base on git history
-          voc4cat transform --prov-from-git --inplace --config idranges.toml --logfile outbox/voc4cat.log vocabularies/
+          voc4cat transform --prov-from-git --diff-base origin/main --inplace --config idranges.toml --logfile outbox/voc4cat.log vocabularies/
 
       - name: Run voc4cat (re-build updated Excel file and joined turtle vocabulary file)
         # Passing the config is important to make use of the prefixes therein.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Select to install a stable tagged version or main branch (in development)
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.0.3
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.0.4
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Select to install a stable tagged version or main branch (in development)
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.0.3
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.0.4
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -120,17 +120,17 @@ After these steps your repository should work just like [voc4cat](https://github
 
 ### Keeping your vocabulary repository in sync with voc4cat-template
 
-To review the changes made in the template in version 1.x.y and compare to when you last pulled it use:
+To review the changes made in the template in version 26.x and compare to when you last pulled it use:
 
 ```gitattributes
-git fetch https://github.com/nfdi4cat/voc4cat-template tag v1.x.y
+git fetch https://github.com/nfdi4cat/voc4cat-template tag v26.x
 git diff ...FETCH_HEAD
 ```
 
 If you want to take over the changes, pull them into your repository
 
 ```gitattributes
-git pull https://github.com/nfdi4cat/voc4cat-template tag v1.x.y
+git pull https://github.com/nfdi4cat/voc4cat-template tag v26.x
 ```
 
 and push the change to the remote repository.

--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ join:
 # Add provenance information to all ttl files in vocabularies/
 [group('individual steps')]
 prov:
-  voc4cat transform --prov-from-git --inplace --config idranges.toml --logfile outbox/voc4cat.log vocabularies/
+  voc4cat transform --prov-from-git --diff-base origin/main --inplace --config idranges.toml --logfile outbox/voc4cat.log vocabularies/
 
 # Run all steps as in gh-actions: check xlsx, convert to SKOS, build docs, re-build xlsx
 all: check convert docs xlsx


### PR DESCRIPTION
Updates the underlying template to v26.2.1 which uses voc4cat-tool v1.0.4. This should fix the excessive dtc:modified updates seen in #255.
