### PR TITLE
Update to voc4cat-tool v1.1.1 and voc4cat-template v26.8.1

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -95,7 +95,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Select to install a stable tagged version or main branch (in development)
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.1.0
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.1.1
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x  (adds sorted collections,
@@ -142,7 +142,7 @@ jobs:
           find inbox-excel-vocabs -name '*.xlsx' -exec cp {} -t outbox/ \;
           git status
           # Add/update dct:created and dct:modified base on git history
-          voc4cat transform --prov-from-git --diff-base origin/main --inplace --config _main_branch/idranges.toml --logfile outbox/voc4cat.log vocabularies/
+          voc4cat transform --prov-from-git --diff-base origin/main --modified-date "$(date +'%Y-%m-%d')" --inplace --config _main_branch/idranges.toml --logfile outbox/voc4cat.log vocabularies/
 
       - name: Run voc4cat (re-build updated Excel file and joined turtle vocabulary file)
         # Passing the config is important to make use of the prefixes therein.

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -65,7 +65,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Select to install a stable tagged version or main branch (in development)
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.1.0
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.1.1
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Select to install a stable tagged version or main branch (in development)
-          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.1.0
+          python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@v1.1.1
           # python -m pip install git+https://github.com/nfdi4cat/voc4cat-tool.git@main
 
           # install custom pylode 2.x

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -152,14 +152,14 @@ After these steps your repository should work just like [voc4cat](https://github
 To review the changes made in the template in version v26.8 and compare to when you last pulled it use:
 
 ```bash
-git fetch https://github.com/nfdi4cat/voc4cat-template tag v26.8
+git fetch --no-tags https://github.com/nfdi4cat/voc4cat-template refs/tags/v26.8
 git diff ...FETCH_HEAD
 ```
 
-If you want to take over the changes, pull them into your repository
+If you want to take over the changes, merge them into your repository
 
 ```bash
-git pull https://github.com/nfdi4cat/voc4cat-template tag v26.8
+git merge FETCH_HEAD -m "Merge voc4cat-template v26.8"
 ```
 
 and push the change to the remote repository.
@@ -167,6 +167,11 @@ and push the change to the remote repository.
 ```bash
 git push
 ```
+
+Use `--no-tags` together with the full `refs/tags/...` path to keep the tags of the template out of your repository.
+The shorter form `tag v26.8` copies that tag into your repository and, with it, every other tag of the template.
+There they are indistinguishable from the release tags of your own vocabulary.
+If an earlier sync brought template tags into your repository, delete them with `git tag -d <tag>` and, where they were pushed, with `git push --delete origin <tag>`.
 
 It is suggested to merge the changes from the template repository before every new release of your vocabulary. This ensures that the centrally maintained features and best practices trickle into your project.
 


### PR DESCRIPTION
Merges voc4cat-template v26.8.1.

**`ci-pr.yml`** now passes the run date to the provenance step to get the correct `dct:modified` dates for updates resulting from the xlsx transformation:

```bash
voc4cat transform --prov-from-git --diff-base origin/main --modified-date "$(date +'%Y-%m-%d')" --inplace ...
```

Concepts unchanged against `origin/main` keep the dates they have there; the concept scheme is dated whenever anything in the vocabulary changed; a concept that has no commit yet also gets the date as `dct:created`.

**The three workflows** move to voc4cat-tool v1.1.1, which also strips surrounding whitespace from labels and definitions on conversion (nfdi4cat/voc4cat-tool#377). That prevents a repeat of #288, where a trailing space in an xlsx cell reached the vocabulary.

**`README_TEMPLATE.md`** carries the corrected sync instructions from nfdi4cat/voc4cat-template#135.

Closes #291