### PR TITLE
Document allowed changes and link the modelling rules

### DIFF
--- a/docs/docs_usage/changing-concepts.md
+++ b/docs/docs_usage/changing-concepts.md
@@ -1,0 +1,122 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Which changes to a Voc4Cat concept are allowed and when: the meaning of an identifier is fixed once published, while hierarchy, mappings and labels stay improvable."
+---
+
+# What may be changed on an existing concept?
+
+A concept in Voc4Cat can be improved after it has been accepted: definitions get sharper, wrong parents get corrected, mappings get added.
+What cannot change is the meaning its identifier carries.
+This page states which changes fall on which side, and from when on.
+
+## The rule
+
+:::{important}
+Once a concept is in Voc4Cat, the meaning its IRI carries is fixed.
+Everything else stays improvable.
+:::
+
+Voc4Cat is a **terminology**, not an ontology or a knowledge graph.
+What it offers is the concept with an identifier, a label, and an agreed definition.
+The hierarchy, the collections and the mappings organize those concepts so they can be found; they are curation rather than axioms that annotated data inherits.
+
+This drives the rules for changing concept labels vs. relations:
+
+- Change what a concept **denotes**, and every dataset annotated with it silently becomes wrong. Nothing warns anyone, because the IRI did not change.
+- Move a concept to a **better parent**, and no dataset becomes wrong. Hierarchical queries return something different, which is the point of the correction.
+
+To test your change request, you can ask:
+
+> Would data that someone has already annotated with this IRI still be about the same thing after my change?
+
+If yes, it is an improvement and allowed.
+If no, you are giving an existing identifier a new meaning: [deprecate the concept](#deprecating-a-concept) and add a new one instead.
+
+## What may be changed, and when
+
+A concept is **in Voc4Cat** as soon as the pull request that introduced it has been merged.
+From that moment it is part of the [development version](https://w3id.org/nfdi4cat/voc4cat/dev) and it may appear in any later release.
+
+| Change class | Where you edit it | New in your pull request | Already in Voc4Cat<br>(development version or release) |
+| --- | --- | --- | --- |
+| **Identity** (what the IRI denotes) | Concepts: *Preferred Label*, *Definition* | free | **not allowed**; deprecate it and add a new concept |
+| **Wording** (same meaning, better phrasing) | Concepts: *Preferred Label*, *Definition* | free | allowed via PR |
+| **Parent relations** (placement in the hierarchy) | Concepts: *Parent IRIs* | free | allowed via PR |
+| **External mappings** | Mappings: *Related*, *Close*, *Exact*, *Narrower*, *Broader Matches* | free | allowed via PR |
+| **Collection membership** | Concepts: *Member of collection(s)*, *Member of ordered collection # position* | free | allowed via PR |
+| **Collection nesting** | Collections: *Parent Collection IRIs* | free | allowed via PR |
+| **Collection identity** (what a collection IRI denotes) | Collections: *Preferred Label*, *Definition* | free | **not allowed**; same rule as for concepts |
+| **Additive** (more labels, translations, notes) | Concepts: *Alternate Labels*, *Change Note*, *Editorial Note*; one row per language | free | allowed via PR |
+| **Deprecation** | Concepts: *Obsoletion reason*, *dct:isReplacedBy* | not needed; correct it instead | allowed via PR |
+| **Deletion** (removing the row) | — | free | **not allowed**; rejected automatically |
+
+What the three verdicts mean:
+
+- **free**: Change it in the pull request you are working on. The concept has not been published yet, so nobody can be relying on it.
+- **allowed via PR**: Submit the change like any other contribution, in its own pull request. A curator reviews it.
+- **not allowed**: The change will be rejected. The table names what to do instead.
+
+:::{note}
+A release does not lock or unlock anything; the rules above apply from the merge onwards.
+With Voc4Cat consumers can pick their own trade-off between stability and being up to date: pin to a [dated release](../index.md#all-releases), to the latest release or to the development version.
+:::
+
+## What counts as the same meaning
+
+The *Preferred Label* is not frozen; the concept behind it is.
+
+| Change | Allowed? | Why |
+| --- | --- | --- |
+| Fixing a [spelling](guidelines.md#spelling-variants), or promoting the [more common term](guidelines.md#preferred-label) for the same thing to *Preferred Label* | yes | Same concept, better wording. |
+| Rewriting a vague definition so that it says the same thing more precisely | yes | The set of things covered does not move. |
+| Narrowing a definition so that cases it used to cover are now excluded | no | Data annotated under the wider reading becomes wrong unnoticed. |
+| Relabelling *external standard concentration* as *internal standard concentration* | no | A different substance, and therefore a different concept. |
+
+The last row is a real request ([issue #280](https://github.com/nfdi4cat/voc4cat/issues/280)): leave the existing concept alone and add a new one if the new meaning is needed.
+
+## Correcting a parent
+
+Correcting a wrong parent is allowed at every stage, and it is expected.
+Changing `skos:broader` does not change what the IRI denotes; it changes where the concept sits.
+
+In Voc4Cat `skos:broader` expresses IS-A relations and nothing else.
+A quick test whenever you set a parent: **is my concept a kind of its parent, or a property of its parent?**
+If it is a property, the parent is wrong.
+The full reasoning, including how to express HAS-A and PART-OF instead, is in [Hierarchies, Relations, and Collections](organizing-concepts.md).
+
+Because a parent correction changes what a hierarchical query returns, name the previous parent in the *Change Note* column.
+
+## Deprecating a concept
+
+Concepts are never deleted once they are in Voc4Cat, because the IRI has to keep resolving for everyone who has used it.
+A concept that should no longer be used is **deprecated**: it stays in the vocabulary, marked as obsolete, and points at a replacement where there is one.
+
+On the concept's row in the **Concepts** sheet, *Obsoletion reason* is a dropdown offering six choices:
+
+- The concept is not clearly defined and usage has been inconsistent.
+- This concept was added in error.
+- More specific concepts were created.
+- This concept was converted to a collection.
+- The meaning of the concept is ambiguous.
+- Lack of evidence that this function/process/component exists.
+
+:::{admonition} Example: deprecating a duplicate
+:class: tip
+`voc4cat:0009001` turns out to duplicate the older `voc4cat:0009002` (IRIs invented for the example). On its row:
+
+| Column | Value |
+| --- | --- |
+| Obsoletion reason | This concept was added in error. |
+| dct:isReplacedBy | `voc4cat:0009002` |
+
+The pipeline sets `owl:deprecated` to `true` and records the reason as a `skos:historyNote`.
+The concept keeps its IRI and stays resolvable; consumers see that it is obsolete and where to go instead.
+:::
+
+:::{caution}
+No concept in Voc4Cat carries `owl:deprecated` yet.
+If you are the first to use it, check the resulting Turtle in the pull request artifacts and report anything unexpected as an [issue](https://github.com/nfdi4cat/voc4cat/issues).
+:::
+
+Collections are deprecated in the same way, using the *Obsoletion reason* and *dct:isReplacedBy* columns of the **Collections** sheet.

--- a/docs/docs_usage/changing-concepts.md
+++ b/docs/docs_usage/changing-concepts.md
@@ -85,8 +85,6 @@ A quick test whenever you set a parent: **is my concept a kind of its parent, or
 If it is a property, the parent is wrong.
 The full reasoning, including how to express HAS-A and PART-OF instead, is in [Hierarchies, Relations, and Collections](organizing-concepts.md).
 
-Because a parent correction changes what a hierarchical query returns, name the previous parent in the *Change Note* column.
-
 ## Deprecating a concept
 
 Concepts are never deleted once they are in Voc4Cat, because the IRI has to keep resolving for everyone who has used it.

--- a/docs/docs_usage/guidelines.md
+++ b/docs/docs_usage/guidelines.md
@@ -26,7 +26,9 @@ Please note that all language dependent parts refer to only the default language
 
 :::{tip}
 In addition to this guidelines page, we also provide the page **[organization of concepts](organizing-concepts.md)**
-that explains Voc4Cat's approach to hierarchy and grouping of concepts.
+that explains Voc4Cat's approach to hierarchy and grouping of concepts,
+and the page **[what may be changed on an existing concept](changing-concepts.md)**
+that says which changes are allowed once a concept has been accepted.
 :::
 
 ## General recommendations
@@ -358,7 +360,7 @@ and the other as an alternate label.
 Mappings are used to relate concepts in Voc4Cat to concepts in other controlled vocabularies or ontologies.
 This enables interoperability, data integration, and reuse across different systems and domains.
 We only add mappings to well-established external vocabularies or ontologies that are relevant to catalysis.
-The mappings are reviewed and approved by the Voc4Cat team before being added to the vocabulary assuring a high level of mapping confidence.
+The mappings are reviewed and approved by the Voc4Cat curators before being added to the vocabulary assuring a high level of mapping confidence.
 In the xlsx vocabulary file, mappings are entered in the dedicated **Mappings** sheet.
 
 Voc4Cat uses the [SKOS](https://www.w3.org/TR/skos-reference/) (Simple Knowledge Organization System) standard for representing mappings.

--- a/docs/docs_usage/how-to-contribute.md
+++ b/docs/docs_usage/how-to-contribute.md
@@ -270,6 +270,8 @@ Allgemeinen an der Grenzfläche statt.</td>
     of it. HAS-A and PART-OF are modelled differently, see
     [Hierarchies, Relations, and Collections](organizing-concepts.md).
     Note that broader/narrower are not transitive.
+    A concept normally has one parent; see
+    [Number of Parents](organizing-concepts.md#number-of-parents) before giving it several.
 
 7. **Member of collection(s)** *(optional)*: Assign this concept to one
     or more collections by collection IRI, one per line.

--- a/docs/docs_usage/how-to-contribute.md
+++ b/docs/docs_usage/how-to-contribute.md
@@ -279,11 +279,16 @@ Allgemeinen an der Grenzfläche statt.</td>
 
 9. **Provenance** *(read-only)*: Auto-populated by the CI pipeline with
     `dct:created` and `dct:modified` dates from git history. Do not edit
-    this column manually.
+    this column manually. Every concept also carries a link to the git
+    blame view of its own turtle file (`dct:provenance`, `rdfs:seeAlso`),
+    where the full history of the concept can be read.
 
 10. **Change Note** *(optional)*: A note documenting changes to the
-    concept (`skos:changeNote`). Use this for general provenance remarks
-    such as “definition aligned with RXN ontology”.
+    concept (`skos:changeNote`). Since the blame view shows what changed,
+    when and by whom, use this column only for what the history does not
+    show: crediting someone who contributed the content but is not the
+    author of the commit, or a rationale that the commit message does not
+    carry for this concept alone.
 
 11. **Editorial Note** *(optional)*: Internal notes for editors and
     curators (`skos:editorialNote`). Not shown in the public vocabulary

--- a/docs/docs_usage/how-to-contribute.md
+++ b/docs/docs_usage/how-to-contribute.md
@@ -401,6 +401,7 @@ These guidelines for suggesting, adding, and editing content to Voc4Cat guarante
 - Keep changes focussed. Solve one issue or add/edit a set of strongly related concepts.
 - Not more than 20 new concepts per PR. This keeps the review process manageable for you and the curators. Less is better!
 - Do not change the Excel template structure (sheet names, header rows, column order).
+- Editing a concept that is already in Voc4Cat? Its meaning is fixed, while its wording, parents and mappings can still be improved. See [what may be changed on an existing concept](changing-concepts.md).
 
 #### Step 7 – Create & iterate on the Pull Request
 
@@ -475,6 +476,7 @@ Here are some points to check before you finally submit the PR:
 - Each concept has prefLabel, definition, and a broader chain to a top concept.
 - Contribution is focused/small enough for review (split if needed).
 - No concepts or collections removed (removals are rejected).
+- Edits to existing concepts leave their meaning unchanged ([what may be changed](changing-concepts.md)).
 - No `.ttl` files edited.
 
 ```{tip}

--- a/docs/docs_usage/how-to-contribute.md
+++ b/docs/docs_usage/how-to-contribute.md
@@ -252,17 +252,24 @@ Allgemeinen an der Grenzfläche statt.</td>
 </tbody>
 </table>
 
-3. **Preferred Label** *(required)*: A simple one-line label for the concept.
+3. **Preferred Label** *(required)*: A simple one-line label for the
+    concept, following the [rules for labels](guidelines.md#preferred-label).
+    A multi-word label has to meet the
+    [criteria for compound terms](guidelines.md#single-vs-multi-word-compound-terms);
+    otherwise split it into simpler concepts.
 
 4. **Definition** *(required)*: The defining description of the *Concept*.
+    See the [rules for definitions](guidelines.md#definitions).
 
 5. **Alternate Labels** *(optional)*: Any other names for this *Concept*,
-    separated by vertical bar "|". To include a vertcial bar in a label, escape it with “\\” like in: “one\\|two”.
+    separated by vertical bar "|". To include a vertical bar in a label, escape it with “\\” like in: “one\\|two”.
 
 6. **Parent IRIs** *(optional)*: IRIs of parent concepts, one per line.
-    This creates a hierarchical relationship: the *Concept* is narrower
-    than its parent, and the parent is broader than the *Concept*
-    (in SKOS terminology). Note that broader/narrower are not transitive.
+    In Voc4Cat this expresses an **IS-A** relation and nothing else: the
+    *Concept* has to be a kind of its parent, never a property or a part
+    of it. HAS-A and PART-OF are modelled differently, see
+    [Hierarchies, Relations, and Collections](organizing-concepts.md).
+    Note that broader/narrower are not transitive.
 
 7. **Member of collection(s)** *(optional)*: Assign this concept to one
     or more collections by collection IRI, one per line.
@@ -302,6 +309,10 @@ Allgemeinen an der Grenzfläche statt.</td>
 16. **Obsoletion reason** *(optional)*: If this concept is being
     deprecated, select a reason from the dropdown. Sets `owl:deprecated`
     to true and records a `skos:historyNote` with the obsoletion reason.
+    Deprecate a concept when its meaning would otherwise have to change;
+    a concept that only needs better wording or a better parent is
+    corrected instead. See
+    [what may be changed on an existing concept](changing-concepts.md).
 
 17. **dct:isReplacedBy** *(optional)*: When deprecating a concept,
     provide the IRI of the replacement concept.

--- a/docs/docs_usage/organizing-concepts.md
+++ b/docs/docs_usage/organizing-concepts.md
@@ -52,9 +52,10 @@ Such **subject hierarchies** with **IS-A** based hierarchies correspond well wit
 # Wrong: Confuses PART-OF ("Window PART-OF reactor") with IS-A
 ```
 
-### Single Location per Attribute Concept
+### Avoid Object-Specific Attribute Concepts
 
-Each attribute concept should appear **once** in the hierarchy at its most appropriate taxonomic level, based on IS-A relations.
+Each attribute concept should be placed at its most appropriate taxonomic level, based on IS-A relations,
+and should not be repeated for every object that it can describe.
 
 **Don't create object-specific attribute concepts:**
 
@@ -95,6 +96,51 @@ A more fundamental error is placing attribute concepts under entity concepts:
     skos:broader :Substrate .
     # Wrong: "Width" is not a subtype of "Substrate"
 ```
+
+### Number of Parents
+
+One parent is the norm.
+A concept may be given more than one parent (a **polyhierarchy**) when it belongs to two independent classifications at the same time.
+Polyhierarchies are permitted by ANSI/NISO Z39.19-2005 (R2010) and ISO 25964-1.
+In Voc4Cat they are the exception, and are used only where all three of the following conditions hold:
+
+1. **Each parent passes the IS-A test on its own.**
+   Every instance of the concept must be an instance of every parent, checked one parent at a time.
+2. **No parent is an ancestor of another parent.**
+   `skos:broader` itself is not transitive, but `skos:broaderTransitive` already yields the ancestor,
+   so such an entry states a relation that holds anyway.
+3. **The parents come from different classifications.**
+   Parents that answer the same question about a concept do not separate anything.
+
+**Correct usage:**
+
+```turtle
+:DetectorDeadTime skos:broader :DeadTime .
+# Classification by kind of quantity
+
+:DetectorDeadTime skos:broader :DetectorPerformanceMeasure .
+# Classification by what the quantity characterizes
+```
+
+**Anti-patterns:**
+
+```turtle
+:DimensionalProperty skos:broader :Attribute .
+
+:Width skos:broader :DimensionalProperty ;
+    skos:broader :Attribute .
+# Wrong: Attribute is already reached through DimensionalProperty (condition 2)
+
+:Width skos:broader :SubstrateProperty ;
+    skos:broader :FilmProperty .
+# Wrong: both parents answer "which object does this describe?" (condition 3)
+```
+
+**Practical check for condition 3**: compare the members of the parent classes.
+If they always contain the same concepts, those classes are one class under several names.
+What then needs revision is the classification, not the number of parents on the concept.
+
+Where a second parent would express a context of use rather than a kind, use a `skos:Collection` instead.
 
 ### Using skos:Collection for HAS-A and Contextual Relations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,7 @@ About <docs_usage/about>
 docs_usage/how-to-use
 docs_usage/how-to-contribute
 Organizing Concepts <docs_usage/organizing-concepts>
+Changing Concepts <docs_usage/changing-concepts>
 docs_usage/guidelines
 Guidelines Publication <docs_usage/published-guidelines>
 ```


### PR DESCRIPTION
`docs/docs_usage/changing-concepts.md` now states the rule and gives the change-class table. The Concepts-sheet column descriptions in the contribution guide now link it, the guidelines and organizing-concepts, so that someone filling in the sheet is told the rule documents exist.

The Change Note column is now documented as being for what the git blame view of a concept does not already show.

Also renames "Voc4Cat team" to "Voc4Cat curators" in the guidelines, the term used everywhere else.

`docs/docs_usage/organizing-concepts.md` now states how many parents a concept may have. The conditions for a polyhierarchy are stated separately: each parent passes IS-A on its own, no parent is an ancestor of another, and the parents come from different classifications.

**We leave this is open for some days (~5) to give time for feedback.**

Closes #286
Closes #287
Closes #293
