### PR TITLE
Update to voc4cat-template v26.8.2

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -124,11 +124,19 @@ jobs:
           fi
 
       - name: Run voc4cat (post-convert checks)
+        env:
+          # The ID ranges belong to the contributor who submitted the concepts.
+          # GITHUB_ACTOR names whoever started the run, which is the CI bot for
+          # the run that the commit of ci-pr-commit.yml triggers, and that bot
+          # holds no range. See issue #136.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.actor }}
         run: |
           # check all ttl file(s) in outbox
           voc4cat check --redundant-hierarchies --config _main_branch/idranges.toml --logfile outbox/voc4cat.log outbox/
-          # check if vocabulary changes are allowed
-          voc4cat check --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --ci-post _main_branch/vocabularies outbox/
+          # check if vocabulary changes are allowed. GITHUB_ACTOR is replaced for
+          # this command only: the env key above and GITHUB_ENV both refuse to
+          # overwrite a GITHUB_* variable, a shell assignment does not.
+          GITHUB_ACTOR="$PR_AUTHOR" voc4cat check --config _main_branch/idranges.toml --logfile outbox/voc4cat.log --ci-post _main_branch/vocabularies outbox/
 
       - name: Run voc4cat (build HTML documentation)
         run: |

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -152,14 +152,14 @@ After these steps your repository should work just like [voc4cat](https://github
 To review the changes made in the template in version v26.8 and compare to when you last pulled it use:
 
 ```bash
-git fetch https://github.com/nfdi4cat/voc4cat-template tag v26.8
+git fetch --no-tags https://github.com/nfdi4cat/voc4cat-template refs/tags/v26.8
 git diff ...FETCH_HEAD
 ```
 
-If you want to take over the changes, pull them into your repository
+If you want to take over the changes, merge them into your repository
 
 ```bash
-git pull https://github.com/nfdi4cat/voc4cat-template tag v26.8
+git merge FETCH_HEAD -m "Merge voc4cat-template v26.8"
 ```
 
 and push the change to the remote repository.
@@ -167,6 +167,11 @@ and push the change to the remote repository.
 ```bash
 git push
 ```
+
+Use `--no-tags` together with the full `refs/tags/...` path to keep the tags of the template out of your repository.
+The shorter form `tag v26.8` copies that tag into your repository and, with it, every other tag of the template.
+There they are indistinguishable from the release tags of your own vocabulary.
+If an earlier sync brought template tags into your repository, delete them with `git tag -d <tag>` and, where they were pushed, with `git push --delete origin <tag>`.
 
 It is suggested to merge the changes from the template repository before every new release of your vocabulary. This ensures that the centrally maintained features and best practices trickle into your project.
 


### PR DESCRIPTION
Syncs the template by merging `refs/tags/v26.8.2` with `--no-tags`. The only file that changes is `.github/workflows/ci-pr.yml` which is modified to use the PR author instead of the `GITHUB_ACTOR`.

This fixes `voc4cat check --ci-post` looking up ID ranges for the bot, see #295, [run 33388605142](https://github.com/nfdi4cat/voc4cat/actions/runs/33388605142/job/99477317542).

Template issue nfdi4cat/voc4cat-template#136, template PR nfdi4cat/voc4cat-template#137.