### PR TITLE
Update to voc4cat-template v26.9

### DIFF
--- a/.github/workflows/ci-pr-commit.yml
+++ b/.github/workflows/ci-pr-commit.yml
@@ -3,7 +3,8 @@
 #
 # This is the privileged half of the PR pipeline. It holds the write token, but
 # it runs no tooling over fork-controlled content: it copies a directory out of
-# an artifact, stages it and pushes. See issue #127 for the reasoning.
+# an artifact, stages it and pushes. See issue nfdi4cat/voc4cat-template#127
+# for the reasoning.
 
 name: Commit CI vocabulary changes
 on:

--- a/.github/workflows/ci-pr-commit.yml
+++ b/.github/workflows/ci-pr-commit.yml
@@ -124,7 +124,8 @@ jobs:
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
-          fetch-depth: 1
+          # The rewrite below needs the branch's commits, not just its tip.
+          fetch-depth: 0
           # Needed to push the commit below. No tool runs over the tree while
           # the credential is on disk.
           persist-credentials: true
@@ -135,6 +136,12 @@ jobs:
           # artifact, stage it, commit and push.
           # https://gh.io/securely-using-pull_request_target
           allow-unsafe-pr-checkout: true
+
+      - name: Fetch the base branch to bound the rewrite
+        if: ${{ steps.validate.outputs.skip != 'true' }}
+        env:
+          BASE_REPO: ${{ github.server_url }}/${{ github.repository }}
+        run: git fetch --no-tags "$BASE_REPO" +refs/heads/main:refs/remotes/base/main
 
       - name: Apply converted vocabulary and stage changes
         id: apply
@@ -156,11 +163,10 @@ jobs:
           cp -r "$RUNNER_TEMP/handoff/vocabularies" vocabularies
           # -A so that files the conversion removed are staged as deletions.
           git add -A vocabularies
-          # The submitted spreadsheets are cleaned up once converted.
-          git rm --quiet --ignore-unmatch -- 'inbox-excel-vocabs/*.xlsx'
           git status --short
 
-      - name: Commit and push on behalf of the PR author
+      - name: Commit on behalf of the PR author
+        id: commit
         if: ${{ steps.validate.outputs.skip != 'true' && steps.apply.outputs.skip != 'true' }}
         env:
           ACTOR: ${{ github.event.workflow_run.actor.login }}
@@ -173,6 +179,7 @@ jobs:
           set -euo pipefail
           if git diff --cached --quiet; then
             echo "::notice::No vocabulary changes to commit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git -c user.name='voc4cat-CI-bot' \
@@ -180,7 +187,82 @@ jobs:
               commit \
               --author="$ACTOR <$ACTOR_ID+$ACTOR@users.noreply.github.com>" \
               -m "CI: vocabulary update in $RUN_URL"
-          git push origin "HEAD:$HEAD_BRANCH"
+
+      - name: Drop the submitted spreadsheets from the branch history and push
+        id: rewrite
+        # Deleting the spreadsheet in a follow-up commit leaves the blob in the
+        # branch's earlier commits, so a merge commit or a rebase merge carries
+        # it into the history of main. Removing the path from every commit of
+        # the branch makes the merge method irrelevant.
+        #
+        # Deliberately not gated on whether the commit step committed: a
+        # resubmission that changes no concept still has to have its
+        # spreadsheet removed. The job as a whole runs only for a conversion
+        # run that succeeded, so a failed check or conversion never gets here.
+        if: >-
+          ${{ steps.validate.outputs.skip != 'true'
+              && steps.apply.outputs.skip != 'true' }}
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          ORIGINAL_TIP: ${{ steps.validate.outputs.head_sha }}
+          FILTER_REPO_VERSION: "2.47.0"
+        run: |
+          set -euo pipefail
+          base=$(git merge-base base/main HEAD)
+          echo "rewrite range: $base..HEAD"
+
+          carriers() {
+            for c in $(git rev-list "$base..HEAD"); do
+              if git ls-tree -r --name-only "$c" -- inbox-excel-vocabs | grep -q '[.]xlsx$'; then
+                echo "$c"
+              fi
+            done
+          }
+
+          before=$(carriers | wc -l)
+          echo "commits carrying a spreadsheet before the rewrite: $before"
+          if [ "$before" -gt 0 ]; then
+            # Scoped to the spreadsheets so that inbox-excel-vocabs/README.md stays.
+            pipx run "git-filter-repo==$FILTER_REPO_VERSION" --path-glob 'inbox-excel-vocabs/*.xlsx' --invert-paths --refs "$base..HEAD" --force
+          fi
+
+          after=$(carriers | wc -l)
+          echo "commits carrying a spreadsheet after the rewrite: $after"
+          if [ "$after" -ne 0 ]; then
+            echo "::error::spreadsheets remain in the branch history; refusing to push"
+            exit 1
+          fi
+
+          # Push when the vocabulary commit, the rewrite, or both moved the
+          # branch away from the tip the conversion ran against.
+          if [ "$(git rev-parse HEAD)" = "$ORIGINAL_TIP" ]; then
+            echo "::notice::Branch unchanged; nothing to push."
+            exit 0
+          fi
+          git push --force origin "HEAD:$HEAD_BRANCH"
+
+          # The branch now equals its base: the submission changed no concept
+          # and the spreadsheet was all it carried.
+          if [ "$(git rev-parse HEAD)" = "$base" ]; then
+            echo "collapsed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Close a submission that changed nothing
+        # Without this the contributor is left with an empty, unmergeable pull
+        # request and no explanation. Closing also removes the trap that the
+        # collapse leaves behind: the branch has moved back to the parent of the
+        # commit that carried the spreadsheet, so that commit is still a
+        # descendant and a plain "git push" would restore it.
+        if: ${{ steps.rewrite.outputs.collapsed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.validate.outputs.number }}
+        run: |
+          set -euo pipefail
+          body='This pull request changes no concept: the submitted spreadsheet converts to the vocabulary that is already on main. The spreadsheet has been removed from the branch, which leaves nothing to merge, so the pull request is closed. To submit a change, edit the spreadsheet and open a new pull request. Do not push the old branch again: the commit that carried the spreadsheet is still a descendant of the branch as it now stands, so an ordinary git push would restore it.'
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body="$body"
+          gh pr close "$PR_NUMBER" --repo "$REPO"
 
       - name: Report failure on the pull request
         if: ${{ failure() }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,7 +8,8 @@
 #
 # The converted vocabulary is handed to ci-pr-commit.yml through an artifact.
 # That workflow holds the write token and commits the result to the PR branch
-# without running any tooling over fork-controlled content. See issue #127.
+# without running any tooling over fork-controlled content.
+# See issue nfdi4cat/voc4cat-template#127.
 
 name: CI on pull request create or update
 on:
@@ -128,7 +129,7 @@ jobs:
           # The ID ranges belong to the contributor who submitted the concepts.
           # GITHUB_ACTOR names whoever started the run, which is the CI bot for
           # the run that the commit of ci-pr-commit.yml triggers, and that bot
-          # holds no range. See issue #136.
+          # holds no range. See issue nfdi4cat/voc4cat-template#136.
           PR_AUTHOR: ${{ github.event.pull_request.user.login || github.actor }}
         run: |
           # check all ttl file(s) in outbox

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -184,3 +184,13 @@ jobs:
               body: commentBody
             });
 
+      - name: Fail a submission from an organization-owned fork
+        # The comment above tells the contributor the pull request cannot be
+        # merged as-is. Only a failing check makes that true: GitHub reports
+        # such a pull request as mergeable, and merging it carries the
+        # submitted spreadsheet into the history of main, because the CI could
+        # not push the branch that would have removed it.
+        if: steps.check-main-branch.outputs.is_from_org == 'true' && steps.check-main-branch.outputs.is_fork == 'true' && steps.check-main-branch.outputs.head_owner_login != steps.check-main-branch.outputs.base_owner_login
+        run: |
+          echo '::error::This pull request comes from a fork owned by an organization. GitHub offers no "Allow edits by maintainers" for such forks, so the CI cannot push the converted vocabulary or remove the submitted spreadsheet. Re-submit from a fork in a personal account.'
+          exit 1

--- a/.github/workflows/pr-no-spreadsheets.yml
+++ b/.github/workflows/pr-no-spreadsheets.yml
@@ -1,0 +1,72 @@
+# This action blocks a pull request whose branch still carries a submitted
+# spreadsheet in any of its commits.
+#
+# ci-pr-commit.yml strips inbox-excel-vocabs/*.xlsx from every commit of the
+# branch once the conversion succeeded, so this check goes green on its own for
+# an ordinary submission. It stays red when that could not happen: a conversion
+# that failed, or a fork owned by an organization, which the bot cannot push
+# to. Merging such a branch puts the spreadsheet into the history of main under
+# every merge method, squash included, because the spreadsheet is still part of
+# the merged tree.
+#
+# Deliberately a workflow of its own rather than a job in ci-pr.yml. As a job
+# there a red result would make the conversion run conclude "failure",
+# ci-pr-commit.yml would never run, the spreadsheet would never be removed and
+# the check could never turn green.
+
+name: No spreadsheets in the branch
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  no_spreadsheet_in_history:
+    # This name is what branch protection makes a required check. Renaming the
+    # job silently stops the protection from applying.
+    name: No spreadsheet in the branch history
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout the pull request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          # Every commit of the branch is examined, not just its tip.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Make the base branch available
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Fail while a spreadsheet is in the branch history
+        run: |
+          set -euo pipefail
+          base=$(git merge-base origin/main HEAD)
+          carriers=""
+          for c in $(git rev-list "$base..HEAD"); do
+            if git ls-tree -r --name-only "$c" -- inbox-excel-vocabs | grep -q '[.]xlsx$'; then
+              carriers="$carriers $c"
+            fi
+          done
+          if [ -z "$carriers" ]; then
+            echo "No spreadsheet in $base..HEAD."
+            exit 0
+          fi
+          echo "Commits still carrying a submitted spreadsheet:"
+          for c in $carriers; do
+            echo "  $c $(git log -1 --format=%s "$c")"
+          done
+          echo "::error::A submitted spreadsheet is still in this branch. The CI removes it once the conversion succeeds; while this check is red the conversion failed or the CI cannot push to the fork. Merging now would put the spreadsheet into the history of main."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ For detailed guidelines and step-by-step instructions, see:
 5. Reviewers will check your contribution
 6. Upon approval, your changes are merged and published
 
-**Note**: Automated checks are informational and won't block your PR (except organization accounts due to GitHub limitations).
+**Note**: Most automated checks are informational. The check "No spreadsheet in the branch history" does block merging: it stays red until the pipeline has removed your Excel file from the branch, which it does by itself once the conversion succeeds. For a fork owned by an organization the pipeline cannot push to your branch, so the check cannot go green and the pull request has to be re-submitted from a fork in a personal account.
 
 ## Questions or Issues?
 

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -75,9 +75,15 @@ Here are the steps for submitting updates in Excel.
   - directly merged by the maintainers
   - or a discussion will be started about what else is needed
   - or why the proposed change may not fit.
-- If you need to fix something, first pull the changes made by the action with `git pull` (or "sync" in GUI).
+- If you need to fix something, first bring your clone in line with the branch as the pipeline left it.
+  To keep submitted xlsx files out of the history, the pipeline rewrites the pull request branch instead of adding to it, so `git pull` does not apply. Reset your branch to the published state:
+
+  ```bash
+  git fetch origin
+  git reset --hard origin/<your-branch>
+  ```
+
   Next, commit further changes to the pull request branch in your clone. This will trigger the pipeline to run again.
-  - If any commits have been made by the CI pipeline, pull the changes to your repo (via "Sync fork" button in GUI) before committing any additional changes.
 
 Finally, when the proposed pull request is accepted, your changes will be integrated in the vocabularies in the folder `vocabularies`.
 The vocabularies are stored in split form using one folder per vocabulary.
@@ -140,6 +146,9 @@ This adds all commits made in the template's main branch to your new repository.
 - Adjust settings of your new GitHub repository. Typically you will want to
   - Forbid pushing to main via [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) (Settings > Branches, edit rules for "main")
   - Set up rules for required approvals (Settings > Branches, edit rules for "main")
+  - Make "No spreadsheet in the branch history" a required status check (Settings > Branches, edit rules for "main").
+    The pipeline removes submitted xlsx files from the pull request branch on its own, but it can only do so when it is able to push to the branch.
+    When it cannot - a failed conversion, or a fork owned by an organization - GitHub still reports the pull request as mergeable, and merging it puts the xlsx file into the history of main.
   - Configure GitHub pages to use as source "deploy from a branch" and select the branch `gh-pages` (Settings > Pages > Build and deployment)
 - Optionally
   - Add a different license for your vocabulary.

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -146,9 +146,10 @@ This adds all commits made in the template's main branch to your new repository.
 - Adjust settings of your new GitHub repository. Typically you will want to
   - Forbid pushing to main via [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) (Settings > Branches, edit rules for "main")
   - Set up rules for required approvals (Settings > Branches, edit rules for "main")
-  - Make "No spreadsheet in the branch history" a required status check (Settings > Branches, edit rules for "main").
+  - Make "No spreadsheet in the branch history" a required status check, and enable "Do not allow bypassing the above settings" (Settings > Branches, edit rules for "main").
     The pipeline removes submitted xlsx files from the pull request branch on its own, but it can only do so when it is able to push to the branch.
     When it cannot - a failed conversion, or a fork owned by an organization - GitHub still reports the pull request as mergeable, and merging it puts the xlsx file into the history of main.
+    Both settings are needed: without the second, repository administrators can merge past the failing check, and administrators are usually the people who press the merge button.
   - Configure GitHub pages to use as source "deploy from a branch" and select the branch `gh-pages` (Settings > Pages > Build and deployment)
 - Optionally
   - Add a different license for your vocabulary.

--- a/docs/docs_maintenance/making-releases.md
+++ b/docs/docs_maintenance/making-releases.md
@@ -30,11 +30,10 @@ Before creating a release, ensure:
 3. You have tested the development documentation to verify correctness
 4. You have commit/push rights to the repository
 
-```{warning}
-Merge pull requests with "Create a merge commit" or "Rebase and merge", never with "Squash and merge".
-The dates telling when a concept was created and last changed are taken from the git history.
-Squashing replaces the commits of a pull request by a single new one, so these dates are lost.
-Squash merging is switched off in the repository settings and should stay off.
+```{note}
+Any merge method may be used.
+The dates telling when a concept was created and last changed are written into the turtle files by the pipeline rather than read back from the commits, and the pipeline keeps the submitted xlsx file out of the branch whichever method is used.
+Squash merging, previously disabled for the dates, is safe again.
 ```
 
 ## Release Process

--- a/docs/docs_usage/how-to-contribute.md
+++ b/docs/docs_usage/how-to-contribute.md
@@ -502,12 +502,14 @@ The artifact is a zip-file with several files that help to diagnose the source o
 If the run succeeded you see a similar job message but with a green checkmark:
 ![GitHub Screenshot of action success](media/succesful-job-with-ttl-commit.png)
 
-The second line with the GitHub icon is a commit created by the pipeline in which
+The second line with the GitHub icon is a commit created by the pipeline. It adds the RDF/turtle (ttl-files) with the SKOS representation.
 
-- the xlsx vocabulary file gets removed and 
-- the RDF/turtle (ttl-files) with the SKOS representation are added.
+The pipeline then rewrites your branch so that the xlsx vocabulary file is in none of its commits and never enters the history of voc4cat. Because the branch is rewritten rather than added to, `git pull` does not apply. If you work on a local checkout on your computer, reset it to the branch as the pipeline published it:
 
-If you work on a local checkout on you computer, you need to pull this commit made on GitHub to your local clone with `git pull`.
+```bash
+git fetch origin
+git reset --hard origin/<your-branch>
+```
 
 **Later updates on your PR**
 

--- a/justfile
+++ b/justfile
@@ -79,7 +79,11 @@ join:
 # Add provenance information to all ttl files in vocabularies/
 [group('individual steps')]
 prov:
-  voc4cat transform --prov-from-git --diff-base origin/main --inplace --config idranges.toml --logfile outbox/voc4cat.log vocabularies/
+  # --modified-date is what ci-pr.yml passes. Without it the date of a changed
+  # concept is read from the commits that touched its file, which a squash
+  # merge replaces with one commit dated at merge time; running this recipe
+  # against such a history would overwrite the dates the pipeline wrote.
+  voc4cat transform --prov-from-git --diff-base origin/main --modified-date "$(date +'%Y-%m-%d')" --inplace --config idranges.toml --logfile outbox/voc4cat.log vocabularies/
 
 # Run all steps as in gh-actions: check xlsx, convert to SKOS, build docs, re-build xlsx
 all: check convert docs xlsx


### PR DESCRIPTION
Syncs [voc4cat-template v26.9](https://github.com/nfdi4cat/voc4cat-template/releases/tag/v26.9), which carries nfdi4cat/voc4cat-template#140. Addresses the 2nd todo in #297.

### What this changes for the pipeline

A submitted spreadsheet used to be deleted in a follow-up commit. That leaves the blob in the branch's earlier commits, so it reached the history of `main` under every merge method except squash - which is how the spreadsheets counted in #297 got there. `ci-pr-commit.yml` now removes `inbox-excel-vocabs/*.xlsx` from every commit of the pull request branch and force-pushes, so the merge method no longer decides anything. Only the pull request branch is rewritten.

`pr-no-spreadsheets.yml` is new: a check that fails while any commit of the branch still carries a spreadsheet. The rewrite needs the CI to be able to push, which fails for a conversion that errored and for a fork owned by an organization; the check is what keeps such a branch from being merged. `pr-checks.yml` now also fails for the organization-fork case it already warned about.

### Documentation

- `CONTRIBUTING.md` - the branch-history check blocks merging; a fork owned by an organization has to be re-submitted from a personal account
- `docs/docs_usage/how-to-contribute.md` - the pipeline rewrites the branch, so a local clone is reset rather than pulled
- `docs/docs_maintenance/making-releases.md` - any merge method may be used

Documentation for adopters of the voc4cat-toolchain is updated in nfdi4cat/voc4cat-tool#383.

### Required after merging

The check reports but does not enforce until both are set for `main` (in Settings of the repo):

- list `No spreadsheet in the branch history` as a required status check
- keep the ruleset's bypass list empty (the ruleset equivalent of "Do not allow bypassing the above settings")

Do not add the required check before this is merged.